### PR TITLE
Display series with first book cover

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/Series.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/model/dto/Series.java
@@ -3,9 +3,13 @@ package com.adityachandel.booklore.model.dto;
 import lombok.AllArgsConstructor;
 import lombok.Data;
 
+import java.time.Instant;
+
 @Data
 @AllArgsConstructor
 public class Series {
     private String name;
     private long bookCount;
+    private Long firstBookId;
+    private Instant coverUpdatedOn;
 }

--- a/booklore-api/src/main/java/com/adityachandel/booklore/repository/BookMetadataRepository.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/repository/BookMetadataRepository.java
@@ -27,8 +27,8 @@ public interface BookMetadataRepository extends JpaRepository<BookMetadataEntity
     List<BookMetadataEntity> findAllByBookIdIn(Set<Long> bookIds);
 
 	
-    @Query("SELECT new com.adityachandel.booklore.model.dto.Series(m.seriesName, COUNT(m)) " +
+    @Query("SELECT new com.adityachandel.booklore.model.dto.Series(m.seriesName, COUNT(m), MIN(m.bookId), MIN(m.coverUpdatedOn)) " +
             "FROM BookMetadataEntity m WHERE m.seriesName IS NOT NULL " +
             "GROUP BY m.seriesName ORDER BY m.seriesName")
-    List<Series> findAllSeriesWithBookCount();    
+    List<Series> findAllSeriesWithBookCount();
 }

--- a/booklore-ui/src/app/book/components/series-browser/series-browser.component.html
+++ b/booklore-ui/src/app/book/components/series-browser/series-browser.component.html
@@ -10,14 +10,9 @@
             </div>
         </div>
 
-        <div class="series-browser">
-            <div *ngFor="let s of series$ | async">
-                <a class="series-card">
-                    <div class="series-meta">
-                        <h3>{{ s.name }}</h3>
-                        <span>{{ s.bookCount }} books</span>
-                    </div>
-                </a>
+        <div class="series-grid">
+            <div *ngFor="let s of series$ | async" class="series-item">
+                <app-series-card [series]="s"></app-series-card>
             </div>
         </div>
     </div>

--- a/booklore-ui/src/app/book/components/series-browser/series-browser.component.scss
+++ b/booklore-ui/src/app/book/components/series-browser/series-browser.component.scss
@@ -1,28 +1,12 @@
 .series-browser {
 }
 
-.series-item {
-  margin-bottom: 0.5rem;
-}
-
 .series-grid {
   display: grid;
   grid-template-columns: repeat(auto-fill, minmax(140px, 1fr));
+  gap: 1rem;
 }
-.series-card {
-  display: flex;
-  flex-direction: column;
-  text-decoration: none;
-  border: 1px solid #e5e5e5;
-  border-radius: 8px;
-  overflow: hidden;
-}
-.series-card img {
-  width: 100%;
-  height: 200px;
-  object-fit: cover;
-}
-.series-meta {
-  padding: .5rem .75rem;
-  color: inherit;
+
+.series-item {
+  margin-bottom: 0;
 }

--- a/booklore-ui/src/app/book/components/series-browser/series-browser.component.ts
+++ b/booklore-ui/src/app/book/components/series-browser/series-browser.component.ts
@@ -1,13 +1,14 @@
 import { Component, inject } from "@angular/core";
 import { AsyncPipe, NgForOf } from "@angular/common";
 import { SeriesService } from "../../service/series.service";
+import { SeriesCardComponent } from "./series-card/series-card.component";
 
 @Component({
   selector: "app-series-browser",
   standalone: true,
   templateUrl: "./series-browser.component.html",
   styleUrls: ["./series-browser.component.scss"],
-  imports: [NgForOf, AsyncPipe],
+  imports: [NgForOf, AsyncPipe, SeriesCardComponent],
 })
 export class SeriesBrowserComponent {
   private seriesService = inject(SeriesService);

--- a/booklore-ui/src/app/book/components/series-browser/series-card/series-card.component.html
+++ b/booklore-ui/src/app/book/components/series-browser/series-card/series-card.component.html
@@ -1,0 +1,20 @@
+<div class="series-card">
+  <div class="cover-container" [ngClass]="{ 'loaded': isImageLoaded }">
+    <img
+      class="series-cover"
+      [src]="urlHelper.getCoverUrl(series.firstBookId, series.coverUpdatedOn)"
+      [class.loaded]="isImageLoaded"
+      alt="Cover of {{ series.name }}"
+      loading="lazy"
+      (load)="onImageLoad()"/>
+
+    <div class="series-count-overlay">{{ series.bookCount }}</div>
+  </div>
+
+  <div>
+    <div class="series-title-container flex items-center">
+      <h4 class="series-title m-0 pl-2">{{ series.name }}</h4>
+    </div>
+  </div>
+</div>
+

--- a/booklore-ui/src/app/book/components/series-browser/series-card/series-card.component.scss
+++ b/booklore-ui/src/app/book/components/series-browser/series-card/series-card.component.scss
@@ -1,0 +1,68 @@
+.series-card {
+  background-color: var(--card-background);
+  border-radius: 8px 8px 8px 8px;
+  overflow: hidden;
+}
+
+.cover-container {
+  position: relative;
+  width: 100%;
+  aspect-ratio: 5/7;
+  background-color: var(--card-background);
+  border-radius: 8px 8px 0 0;
+  overflow: hidden;
+  display: flex;
+  align-items: center;
+  justify-content: center;
+}
+
+.cover-container.loaded {
+  background-color: transparent;
+}
+
+.series-cover {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  border-radius: 8px 8px 0 0;
+  transition: opacity 0.3s ease-in;
+  opacity: 0;
+}
+
+.series-cover.loaded {
+  opacity: 1;
+}
+
+.series-count-overlay {
+  position: absolute;
+  top: 4px;
+  right: 4px;
+  background-color: var(--primary-color);
+  color: var(--primary-text-color-dark);
+  font-size: 0.75rem;
+  padding: 1px 6px;
+  border-radius: 3px;
+  z-index: 3;
+  white-space: nowrap;
+  user-select: none;
+  font-weight: 600;
+  text-align: center;
+  box-shadow: 0 0 4px rgba(0, 0, 0, 0.15);
+}
+
+.series-title-container {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+}
+
+.series-title {
+  flex-grow: 1;
+  font-size: 0.9rem;
+  color: var(--text-color);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  text-align: center;
+}
+

--- a/booklore-ui/src/app/book/components/series-browser/series-card/series-card.component.ts
+++ b/booklore-ui/src/app/book/components/series-browser/series-card/series-card.component.ts
@@ -1,0 +1,23 @@
+import {Component, Input, inject} from '@angular/core';
+import {Series} from '../../../model/series.model';
+import {UrlHelperService} from '../../../../utilities/service/url-helper.service';
+import {NgClass} from '@angular/common';
+
+@Component({
+  selector: 'app-series-card',
+  standalone: true,
+  templateUrl: './series-card.component.html',
+  styleUrls: ['./series-card.component.scss'],
+  imports: [NgClass]
+})
+export class SeriesCardComponent {
+  @Input() series!: Series;
+
+  isImageLoaded: boolean = false;
+  protected urlHelper = inject(UrlHelperService);
+
+  onImageLoad(): void {
+    this.isImageLoaded = true;
+  }
+}
+

--- a/booklore-ui/src/app/book/model/series.model.ts
+++ b/booklore-ui/src/app/book/model/series.model.ts
@@ -1,5 +1,6 @@
 export interface Series {
   name: string;
   bookCount: number;
-  coverUrl?: string;
+  firstBookId: number;
+  coverUpdatedOn?: string;
 }


### PR DESCRIPTION
## Summary
- Extend series DTO and repository query to include first book identifier and cover timestamp
- Add SeriesCard component and grid view to show each series using first book's cover

## Testing
- `./gradlew test` *(fails: Could not resolve dependencies from Maven Central 403)*
- `npm ci` *(fails: peer dependency conflict between primeng and @angular/animations)*
- `npm test -- --watch=false` *(fails: ng: not found)*

------
https://chatgpt.com/codex/tasks/task_e_6899830bcc508320ae421947cc440e4f