### PR TITLE
Extract metadata from CBZ ComicInfo

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
@@ -6,11 +6,25 @@ import org.apache.commons.io.FilenameUtils;
 import org.springframework.stereotype.Component;
 
 import javax.imageio.ImageIO;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 @Slf4j
 @Component
@@ -19,9 +33,142 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
     @Override
     public BookMetadata extractMetadata(File file) {
         String baseName = FilenameUtils.getBaseName(file.getName());
-        return BookMetadata.builder()
-                .title(baseName)
-                .build();
+        if (!file.getName().toLowerCase().endsWith(".cbz")) {
+            return BookMetadata.builder().title(baseName).build();
+        }
+
+        try (ZipFile zipFile = new ZipFile(file)) {
+            ZipEntry entry = findComicInfoEntry(zipFile);
+            if (entry == null) {
+                return BookMetadata.builder().title(baseName).build();
+            }
+
+            try (InputStream is = zipFile.getInputStream(entry)) {
+                Document document = buildSecureDocument(is);
+                return mapDocumentToMetadata(document, baseName);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to extract metadata from CBZ", e);
+            return BookMetadata.builder().title(baseName).build();
+        }
+    }
+
+    private ZipEntry findComicInfoEntry(ZipFile zipFile) {
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            String name = entry.getName();
+            if ("comicinfo.xml".equalsIgnoreCase(name)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private Document buildSecureDocument(InputStream is) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setExpandEntityReferences(false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(is);
+    }
+
+    private BookMetadata mapDocumentToMetadata(Document document, String fallbackTitle) {
+        BookMetadata.BookMetadataBuilder builder = BookMetadata.builder();
+
+        String title = getTextContent(document, "Title");
+        builder.title(title == null || title.isBlank() ? fallbackTitle : title);
+
+        builder.description(coalesce(getTextContent(document, "Summary"), getTextContent(document, "Description")));
+        builder.publisher(getTextContent(document, "Publisher"));
+        builder.seriesName(getTextContent(document, "Series"));
+        builder.seriesNumber(parseFloat(getTextContent(document, "Number")));
+        builder.seriesTotal(parseInteger(getTextContent(document, "Count")));
+        builder.publishedDate(parseDate(getTextContent(document, "Year"),
+                getTextContent(document, "Month"), getTextContent(document, "Day")));
+        builder.pageCount(parseInteger(coalesce(getTextContent(document, "PageCount"),
+                getTextContent(document, "Pages"))));
+        builder.language(getTextContent(document, "LanguageISO"));
+
+        Set<String> authors = new HashSet<>();
+        authors.addAll(splitValues(getTextContent(document, "Writer")));
+        authors.addAll(splitValues(getTextContent(document, "Penciller")));
+        authors.addAll(splitValues(getTextContent(document, "Inker")));
+        authors.addAll(splitValues(getTextContent(document, "Colorist")));
+        authors.addAll(splitValues(getTextContent(document, "Letterer")));
+        authors.addAll(splitValues(getTextContent(document, "CoverArtist")));
+        if (!authors.isEmpty()) {
+            builder.authors(authors);
+        }
+
+        Set<String> categories = new HashSet<>();
+        categories.addAll(splitValues(getTextContent(document, "Genre")));
+        categories.addAll(splitValues(getTextContent(document, "Tags")));
+        if (!categories.isEmpty()) {
+            builder.categories(categories);
+        }
+
+        return builder.build();
+    }
+
+    private String getTextContent(Document document, String tag) {
+        NodeList nodes = document.getElementsByTagName(tag);
+        if (nodes.getLength() == 0) {
+            return null;
+        }
+        return nodes.item(0).getTextContent().trim();
+    }
+
+    private String coalesce(String a, String b) {
+        return (a != null && !a.isBlank()) ? a : (b != null && !b.isBlank() ? b : null);
+    }
+
+    private Set<String> splitValues(String value) {
+        if (value == null) {
+            return new HashSet<>();
+        }
+        return Arrays.stream(value.split("[,;]"))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(HashSet::new, Set::add, Set::addAll);
+    }
+
+    private Integer parseInteger(String value) {
+        try {
+            return (value == null || value.isBlank()) ? null : Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Float parseFloat(String value) {
+        try {
+            return (value == null || value.isBlank()) ? null : Float.parseFloat(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private LocalDate parseDate(String year, String month, String day) {
+        Integer y = parseInteger(year);
+        Integer m = parseInteger(month);
+        Integer d = parseInteger(day);
+        if (y == null) {
+            return null;
+        }
+        if (m == null) {
+            m = 1;
+        }
+        if (d == null) {
+            d = 1;
+        }
+        try {
+            return LocalDate.of(y, m, d);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     @Override

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractorTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractorTest.java
@@ -1,0 +1,97 @@
+package com.adityachandel.booklore.service.metadata.extractor;
+
+import com.adityachandel.booklore.model.dto.BookMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CbxMetadataExtractorTest {
+
+    private final CbxMetadataExtractor extractor = new CbxMetadataExtractor();
+
+    private File createCbz(String fileName, String entryName, String xmlContent) throws IOException {
+        Path dir = Files.createTempDirectory("cbz");
+        Path file = dir.resolve(fileName);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(file))) {
+            if (entryName != null && xmlContent != null) {
+                ZipEntry entry = new ZipEntry(entryName);
+                zos.putNextEntry(entry);
+                zos.write(xmlContent.getBytes());
+                zos.closeEntry();
+            }
+        }
+        return file.toFile();
+    }
+
+    @Test
+    void extractsMetadataWithMultipleAuthors() throws Exception {
+        String xml = "<ComicInfo>" +
+                "<Title>Sample</Title>" +
+                "<Summary>Summary text</Summary>" +
+                "<Publisher>Marvel</Publisher>" +
+                "<Series>Series A</Series>" +
+                "<Number>5</Number>" +
+                "<Count>10</Count>" +
+                "<Year>2020</Year><Month>6</Month><Day>15</Day>" +
+                "<PageCount>25</PageCount>" +
+                "<LanguageISO>en</LanguageISO>" +
+                "<Writer>Writer1, Writer2; Writer3</Writer>" +
+                "<Penciller>Penciller1</Penciller>" +
+                "<Genre>Action;Adventure</Genre>" +
+                "<Tags>Sci-Fi</Tags>" +
+                "</ComicInfo>";
+        File cbz = createCbz("multipleAuthors.cbz", "ComicInfo.xml", xml);
+
+        BookMetadata md = extractor.extractMetadata(cbz);
+
+        assertThat(md.getTitle()).isEqualTo("Sample");
+        assertThat(md.getDescription()).isEqualTo("Summary text");
+        assertThat(md.getPublisher()).isEqualTo("Marvel");
+        assertThat(md.getSeriesName()).isEqualTo("Series A");
+        assertThat(md.getSeriesNumber()).isEqualTo(5f);
+        assertThat(md.getSeriesTotal()).isEqualTo(10);
+        assertThat(md.getPublishedDate()).isEqualTo(java.time.LocalDate.of(2020, 6, 15));
+        assertThat(md.getPageCount()).isEqualTo(25);
+        assertThat(md.getLanguage()).isEqualTo("en");
+        assertThat(md.getAuthors()).containsExactlyInAnyOrder("Writer1", "Writer2", "Writer3", "Penciller1");
+        assertThat(md.getCategories()).containsExactlyInAnyOrder("Action", "Adventure", "Sci-Fi");
+    }
+
+    @Test
+    void handlesMissingFields() throws Exception {
+        String xml = "<ComicInfo><Title>OnlyTitle</Title></ComicInfo>";
+        File cbz = createCbz("missing.cbz", "ComicInfo.xml", xml);
+
+        BookMetadata md = extractor.extractMetadata(cbz);
+
+        assertThat(md.getTitle()).isEqualTo("OnlyTitle");
+        assertThat(md.getPublisher()).isNull();
+        assertThat(md.getAuthors()).isNull();
+    }
+
+    @Test
+    void findsEntryCaseInsensitively() throws Exception {
+        String xml = "<ComicInfo><Title>CaseTest</Title></ComicInfo>";
+        File cbz = createCbz("CaseFile.CBZ", "comicinfo.xml", xml);
+
+        BookMetadata md = extractor.extractMetadata(cbz);
+
+        assertThat(md.getTitle()).isEqualTo("CaseTest");
+    }
+
+    @Test
+    void fallsBackToFilenameWhenComicInfoMissing() throws Exception {
+        File cbz = createCbz("nofile.cbz", "Other.xml", "<root/>");
+
+        BookMetadata md = extractor.extractMetadata(cbz);
+
+        assertThat(md.getTitle()).isEqualTo("nofile");
+    }
+}


### PR DESCRIPTION
## Summary
- parse ComicInfo.xml from CBZ archives to populate BookMetadata
- add helper parsers for numbers and publication dates
- cover extraction logic with unit tests for authors, missing fields, case sensitivity and missing ComicInfo

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.1 ... status code 403 from server)*

------
https://chatgpt.com/codex/tasks/task_e_689a858837708320a6c3e3cc3fa3f79c