### PR TITLE
Handle ComicInfo metadata for CBZ archives

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractor.java
@@ -6,11 +6,25 @@ import org.apache.commons.io.FilenameUtils;
 import org.springframework.stereotype.Component;
 
 import javax.imageio.ImageIO;
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import org.w3c.dom.Document;
+import org.w3c.dom.NodeList;
+
 import java.awt.*;
 import java.awt.image.BufferedImage;
 import java.io.ByteArrayOutputStream;
 import java.io.File;
 import java.io.IOException;
+import java.io.InputStream;
+import java.time.LocalDate;
+import java.util.Arrays;
+import java.util.Enumeration;
+import java.util.HashSet;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
 
 @Slf4j
 @Component
@@ -19,9 +33,142 @@ public class CbxMetadataExtractor implements FileMetadataExtractor {
     @Override
     public BookMetadata extractMetadata(File file) {
         String baseName = FilenameUtils.getBaseName(file.getName());
-        return BookMetadata.builder()
-                .title(baseName)
-                .build();
+        if (!file.getName().toLowerCase().endsWith(".cbz")) {
+            return BookMetadata.builder().title(baseName).build();
+        }
+
+        try (ZipFile zipFile = new ZipFile(file)) {
+            ZipEntry entry = findComicInfoEntry(zipFile);
+            if (entry == null) {
+                return BookMetadata.builder().title(baseName).build();
+            }
+
+            try (InputStream is = zipFile.getInputStream(entry)) {
+                Document document = buildSecureDocument(is);
+                return mapDocumentToMetadata(document, baseName);
+            }
+        } catch (Exception e) {
+            log.warn("Failed to extract metadata from CBZ", e);
+            return BookMetadata.builder().title(baseName).build();
+        }
+    }
+
+    private ZipEntry findComicInfoEntry(ZipFile zipFile) {
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            String name = entry.getName();
+            if ("comicinfo.xml".equalsIgnoreCase(name)) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private Document buildSecureDocument(InputStream is) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setExpandEntityReferences(false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(is);
+    }
+
+    private BookMetadata mapDocumentToMetadata(Document document, String fallbackTitle) {
+        BookMetadata.BookMetadataBuilder builder = BookMetadata.builder();
+
+        String title = getTextContent(document, "Title");
+        builder.title(title == null || title.isBlank() ? fallbackTitle : title);
+
+        builder.description(coalesce(getTextContent(document, "Summary"), getTextContent(document, "Description")));
+        builder.publisher(getTextContent(document, "Publisher"));
+        builder.seriesName(getTextContent(document, "Series"));
+        builder.seriesNumber(parseFloat(getTextContent(document, "Number")));
+        builder.seriesTotal(parseInteger(getTextContent(document, "Count")));
+        builder.publishedDate(parseDate(getTextContent(document, "Year"),
+                getTextContent(document, "Month"), getTextContent(document, "Day")));
+        builder.pageCount(parseInteger(coalesce(getTextContent(document, "PageCount"),
+                getTextContent(document, "Pages"))));
+        builder.language(getTextContent(document, "LanguageISO"));
+
+        Set<String> authors = new HashSet<>();
+        authors.addAll(splitValues(getTextContent(document, "Writer")));
+        authors.addAll(splitValues(getTextContent(document, "Penciller")));
+        authors.addAll(splitValues(getTextContent(document, "Inker")));
+        authors.addAll(splitValues(getTextContent(document, "Colorist")));
+        authors.addAll(splitValues(getTextContent(document, "Letterer")));
+        authors.addAll(splitValues(getTextContent(document, "CoverArtist")));
+        if (!authors.isEmpty()) {
+            builder.authors(authors);
+        }
+
+        Set<String> categories = new HashSet<>();
+        categories.addAll(splitValues(getTextContent(document, "Genre")));
+        categories.addAll(splitValues(getTextContent(document, "Tags")));
+        if (!categories.isEmpty()) {
+            builder.categories(categories);
+        }
+
+        return builder.build();
+    }
+
+    private String getTextContent(Document document, String tag) {
+        NodeList nodes = document.getElementsByTagName(tag);
+        if (nodes.getLength() == 0) {
+            return null;
+        }
+        return nodes.item(0).getTextContent().trim();
+    }
+
+    private String coalesce(String a, String b) {
+        return (a != null && !a.isBlank()) ? a : (b != null && !b.isBlank() ? b : null);
+    }
+
+    private Set<String> splitValues(String value) {
+        if (value == null) {
+            return new HashSet<>();
+        }
+        return Arrays.stream(value.split("[,;]"))
+                .map(String::trim)
+                .filter(s -> !s.isEmpty())
+                .collect(HashSet::new, Set::add, Set::addAll);
+    }
+
+    private Integer parseInteger(String value) {
+        try {
+            return (value == null || value.isBlank()) ? null : Integer.parseInt(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private Float parseFloat(String value) {
+        try {
+            return (value == null || value.isBlank()) ? null : Float.parseFloat(value.trim());
+        } catch (NumberFormatException e) {
+            return null;
+        }
+    }
+
+    private LocalDate parseDate(String year, String month, String day) {
+        Integer y = parseInteger(year);
+        Integer m = parseInteger(month);
+        Integer d = parseInteger(day);
+        if (y == null) {
+            return null;
+        }
+        if (m == null) {
+            m = 1;
+        }
+        if (d == null) {
+            d = 1;
+        }
+        try {
+            return LocalDate.of(y, m, d);
+        } catch (Exception e) {
+            return null;
+        }
     }
 
     @Override

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriter.java
@@ -1,0 +1,181 @@
+package com.adityachandel.booklore.service.metadata.writer;
+
+import com.adityachandel.booklore.model.MetadataClearFlags;
+import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.enums.BookFileType;
+import lombok.extern.slf4j.Slf4j;
+import org.springframework.stereotype.Component;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+import org.w3c.dom.NodeList;
+
+import javax.xml.XMLConstants;
+import javax.xml.parsers.DocumentBuilder;
+import javax.xml.parsers.DocumentBuilderFactory;
+import javax.xml.transform.OutputKeys;
+import javax.xml.transform.Transformer;
+import javax.xml.transform.TransformerFactory;
+import javax.xml.transform.dom.DOMSource;
+import javax.xml.transform.stream.StreamResult;
+import java.io.ByteArrayOutputStream;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.nio.file.StandardCopyOption;
+import java.time.LocalDate;
+import java.util.Enumeration;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+@Slf4j
+@Component
+public class CbxMetadataWriter implements MetadataWriter {
+
+    @Override
+    public void writeMetadataToFile(File file, BookMetadataEntity metadata, String thumbnailUrl, boolean restoreMode, MetadataClearFlags clearFlags) {
+        try {
+            Path temp = Files.createTempFile("cbx_edit", ".cbz");
+            try (ZipFile zipFile = new ZipFile(file);
+                 ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(temp))) {
+
+                ZipEntry existing = findComicInfoEntry(zipFile);
+                Document doc;
+                if (existing != null) {
+                    try (InputStream is = zipFile.getInputStream(existing)) {
+                        doc = buildSecureDocument(is);
+                    }
+                } else {
+                    DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+                    factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+                    factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+                    DocumentBuilder builder = factory.newDocumentBuilder();
+                    doc = builder.newDocument();
+                    doc.appendChild(doc.createElement("ComicInfo"));
+                }
+                Element root = doc.getDocumentElement();
+                MetadataCopyHelper helper = new MetadataCopyHelper(metadata);
+
+                helper.copyTitle(restoreMode, clearFlags != null && clearFlags.isTitle(), val -> setElement(doc, root, "Title", val));
+                helper.copyDescription(restoreMode, clearFlags != null && clearFlags.isDescription(), val -> {
+                    setElement(doc, root, "Summary", val);
+                    removeElement(root, "Description");
+                });
+                helper.copyPublisher(restoreMode, clearFlags != null && clearFlags.isPublisher(), val -> setElement(doc, root, "Publisher", val));
+                helper.copySeriesName(restoreMode, clearFlags != null && clearFlags.isSeriesName(), val -> setElement(doc, root, "Series", val));
+                helper.copySeriesNumber(restoreMode, clearFlags != null && clearFlags.isSeriesNumber(), val -> setElement(doc, root, "Number", formatFloat(val)));
+                helper.copySeriesTotal(restoreMode, clearFlags != null && clearFlags.isSeriesTotal(), val -> setElement(doc, root, "Count", val != null ? val.toString() : null));
+                helper.copyPublishedDate(restoreMode, clearFlags != null && clearFlags.isPublishedDate(), date -> setDateElements(doc, root, date));
+                helper.copyPageCount(restoreMode, clearFlags != null && clearFlags.isPageCount(), val -> setElement(doc, root, "PageCount", val != null ? val.toString() : null));
+                helper.copyLanguage(restoreMode, clearFlags != null && clearFlags.isLanguage(), val -> setElement(doc, root, "LanguageISO", val));
+                helper.copyAuthors(restoreMode, clearFlags != null && clearFlags.isAuthors(), set -> {
+                    setElement(doc, root, "Writer", join(set));
+                    removeElement(root, "Penciller");
+                    removeElement(root, "Inker");
+                    removeElement(root, "Colorist");
+                    removeElement(root, "Letterer");
+                    removeElement(root, "CoverArtist");
+                });
+                helper.copyCategories(restoreMode, clearFlags != null && clearFlags.isCategories(), set -> {
+                    setElement(doc, root, "Genre", join(set));
+                    removeElement(root, "Tags");
+                });
+
+                Transformer transformer = TransformerFactory.newInstance().newTransformer();
+                transformer.setOutputProperty(OutputKeys.INDENT, "yes");
+                transformer.setOutputProperty(OutputKeys.ENCODING, "UTF-8");
+                ByteArrayOutputStream baos = new ByteArrayOutputStream();
+                transformer.transform(new DOMSource(doc), new StreamResult(baos));
+                byte[] xmlBytes = baos.toByteArray();
+
+                Enumeration<? extends ZipEntry> entries = zipFile.entries();
+                while (entries.hasMoreElements()) {
+                    ZipEntry entry = entries.nextElement();
+                    if (existing != null && entry.getName().equals(existing.getName())) {
+                        continue;
+                    }
+                    zos.putNextEntry(new ZipEntry(entry.getName()));
+                    try (InputStream is = zipFile.getInputStream(entry)) {
+                        is.transferTo(zos);
+                    }
+                    zos.closeEntry();
+                }
+
+                String entryName = existing != null ? existing.getName() : "ComicInfo.xml";
+                zos.putNextEntry(new ZipEntry(entryName));
+                zos.write(xmlBytes);
+                zos.closeEntry();
+            }
+            Files.move(temp, file.toPath(), StandardCopyOption.REPLACE_EXISTING);
+        } catch (Exception e) {
+            log.warn("Failed to write metadata to CBZ file {}: {}", file.getName(), e.getMessage(), e);
+        }
+    }
+
+    private ZipEntry findComicInfoEntry(ZipFile zipFile) {
+        Enumeration<? extends ZipEntry> entries = zipFile.entries();
+        while (entries.hasMoreElements()) {
+            ZipEntry entry = entries.nextElement();
+            if ("comicinfo.xml".equalsIgnoreCase(entry.getName())) {
+                return entry;
+            }
+        }
+        return null;
+    }
+
+    private Document buildSecureDocument(InputStream is) throws Exception {
+        DocumentBuilderFactory factory = DocumentBuilderFactory.newInstance();
+        factory.setFeature(XMLConstants.FEATURE_SECURE_PROCESSING, true);
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_DTD, "");
+        factory.setAttribute(XMLConstants.ACCESS_EXTERNAL_SCHEMA, "");
+        factory.setExpandEntityReferences(false);
+        DocumentBuilder builder = factory.newDocumentBuilder();
+        return builder.parse(is);
+    }
+
+    private void setElement(Document doc, Element root, String tag, String value) {
+        removeElement(root, tag);
+        if (value != null && !value.isBlank()) {
+            Element el = doc.createElement(tag);
+            el.setTextContent(value);
+            root.appendChild(el);
+        }
+    }
+
+    private void removeElement(Element root, String tag) {
+        NodeList nodes = root.getElementsByTagName(tag);
+        for (int i = nodes.getLength() - 1; i >= 0; i--) {
+            root.removeChild(nodes.item(i));
+        }
+    }
+
+    private void setDateElements(Document doc, Element root, LocalDate date) {
+        if (date == null) {
+            removeElement(root, "Year");
+            removeElement(root, "Month");
+            removeElement(root, "Day");
+            return;
+        }
+        setElement(doc, root, "Year", Integer.toString(date.getYear()));
+        setElement(doc, root, "Month", Integer.toString(date.getMonthValue()));
+        setElement(doc, root, "Day", Integer.toString(date.getDayOfMonth()));
+    }
+
+    private String join(Set<String> set) {
+        return (set == null || set.isEmpty()) ? null : String.join(", ", set);
+    }
+
+    private String formatFloat(Float val) {
+        if (val == null) return null;
+        if (val % 1 == 0) return Integer.toString(val.intValue());
+        return String.format(java.util.Locale.US, "%s", val);
+    }
+
+    @Override
+    public BookFileType getSupportedBookType() {
+        return BookFileType.CBX;
+    }
+}

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractorTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/extractor/CbxMetadataExtractorTest.java
@@ -1,0 +1,97 @@
+package com.adityachandel.booklore.service.metadata.extractor;
+
+import com.adityachandel.booklore.model.dto.BookMetadata;
+import org.junit.jupiter.api.Test;
+
+import java.io.File;
+import java.io.IOException;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CbxMetadataExtractorTest {
+
+    private final CbxMetadataExtractor extractor = new CbxMetadataExtractor();
+
+    private File createCbz(String fileName, String entryName, String xmlContent) throws IOException {
+        Path dir = Files.createTempDirectory("cbz");
+        Path file = dir.resolve(fileName);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(file))) {
+            if (entryName != null && xmlContent != null) {
+                ZipEntry entry = new ZipEntry(entryName);
+                zos.putNextEntry(entry);
+                zos.write(xmlContent.getBytes());
+                zos.closeEntry();
+            }
+        }
+        return file.toFile();
+    }
+
+    @Test
+    void extractsMetadataWithMultipleAuthors() throws Exception {
+        String xml = "<ComicInfo>" +
+                "<Title>Sample</Title>" +
+                "<Summary>Summary text</Summary>" +
+                "<Publisher>Marvel</Publisher>" +
+                "<Series>Series A</Series>" +
+                "<Number>5</Number>" +
+                "<Count>10</Count>" +
+                "<Year>2020</Year><Month>6</Month><Day>15</Day>" +
+                "<PageCount>25</PageCount>" +
+                "<LanguageISO>en</LanguageISO>" +
+                "<Writer>Writer1, Writer2; Writer3</Writer>" +
+                "<Penciller>Penciller1</Penciller>" +
+                "<Genre>Action;Adventure</Genre>" +
+                "<Tags>Sci-Fi</Tags>" +
+                "</ComicInfo>";
+        File cbz = createCbz("multipleAuthors.cbz", "ComicInfo.xml", xml);
+
+        BookMetadata md = extractor.extractMetadata(cbz);
+
+        assertThat(md.getTitle()).isEqualTo("Sample");
+        assertThat(md.getDescription()).isEqualTo("Summary text");
+        assertThat(md.getPublisher()).isEqualTo("Marvel");
+        assertThat(md.getSeriesName()).isEqualTo("Series A");
+        assertThat(md.getSeriesNumber()).isEqualTo(5f);
+        assertThat(md.getSeriesTotal()).isEqualTo(10);
+        assertThat(md.getPublishedDate()).isEqualTo(java.time.LocalDate.of(2020, 6, 15));
+        assertThat(md.getPageCount()).isEqualTo(25);
+        assertThat(md.getLanguage()).isEqualTo("en");
+        assertThat(md.getAuthors()).containsExactlyInAnyOrder("Writer1", "Writer2", "Writer3", "Penciller1");
+        assertThat(md.getCategories()).containsExactlyInAnyOrder("Action", "Adventure", "Sci-Fi");
+    }
+
+    @Test
+    void handlesMissingFields() throws Exception {
+        String xml = "<ComicInfo><Title>OnlyTitle</Title></ComicInfo>";
+        File cbz = createCbz("missing.cbz", "ComicInfo.xml", xml);
+
+        BookMetadata md = extractor.extractMetadata(cbz);
+
+        assertThat(md.getTitle()).isEqualTo("OnlyTitle");
+        assertThat(md.getPublisher()).isNull();
+        assertThat(md.getAuthors()).isNull();
+    }
+
+    @Test
+    void findsEntryCaseInsensitively() throws Exception {
+        String xml = "<ComicInfo><Title>CaseTest</Title></ComicInfo>";
+        File cbz = createCbz("CaseFile.CBZ", "comicinfo.xml", xml);
+
+        BookMetadata md = extractor.extractMetadata(cbz);
+
+        assertThat(md.getTitle()).isEqualTo("CaseTest");
+    }
+
+    @Test
+    void fallsBackToFilenameWhenComicInfoMissing() throws Exception {
+        File cbz = createCbz("nofile.cbz", "Other.xml", "<root/>");
+
+        BookMetadata md = extractor.extractMetadata(cbz);
+
+        assertThat(md.getTitle()).isEqualTo("nofile");
+    }
+}

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriterTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/writer/CbxMetadataWriterTest.java
@@ -1,0 +1,101 @@
+package com.adityachandel.booklore.service.metadata.writer;
+
+import com.adityachandel.booklore.model.MetadataClearFlags;
+import com.adityachandel.booklore.model.entity.AuthorEntity;
+import com.adityachandel.booklore.model.entity.BookMetadataEntity;
+import com.adityachandel.booklore.model.entity.CategoryEntity;
+import org.junit.jupiter.api.Test;
+import org.w3c.dom.Document;
+import org.w3c.dom.Element;
+
+import javax.xml.parsers.DocumentBuilderFactory;
+import java.io.File;
+import java.io.InputStream;
+import java.nio.file.Files;
+import java.nio.file.Path;
+import java.time.LocalDate;
+import java.util.Set;
+import java.util.zip.ZipEntry;
+import java.util.zip.ZipFile;
+import java.util.zip.ZipOutputStream;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class CbxMetadataWriterTest {
+
+    private final CbxMetadataWriter writer = new CbxMetadataWriter();
+
+    private File createCbz(String name, String entryName, String xml) throws Exception {
+        Path dir = Files.createTempDirectory("cbz");
+        Path path = dir.resolve(name);
+        try (ZipOutputStream zos = new ZipOutputStream(Files.newOutputStream(path))) {
+            if (entryName != null && xml != null) {
+                zos.putNextEntry(new ZipEntry(entryName));
+                zos.write(xml.getBytes());
+                zos.closeEntry();
+            }
+        }
+        return path.toFile();
+    }
+
+    private Document readComicInfo(File cbz) throws Exception {
+        try (ZipFile zip = new ZipFile(cbz)) {
+            ZipEntry entry = zip.stream()
+                    .filter(e -> e.getName().equalsIgnoreCase("ComicInfo.xml"))
+                    .findFirst().orElseThrow();
+            try (InputStream is = zip.getInputStream(entry)) {
+                return DocumentBuilderFactory.newInstance().newDocumentBuilder().parse(is);
+            }
+        }
+    }
+
+    @Test
+    void writesMetadataIntoNewComicInfo() throws Exception {
+        File cbz = createCbz("new.cbz", null, null);
+        BookMetadataEntity md = BookMetadataEntity.builder()
+                .title("Sample")
+                .description("Desc")
+                .publisher("Pub")
+                .seriesName("Series")
+                .seriesNumber(1f)
+                .seriesTotal(5)
+                .publishedDate(LocalDate.of(2022,3,4))
+                .pageCount(30)
+                .language("en")
+                .authors(Set.of(AuthorEntity.builder().name("A1").build(), AuthorEntity.builder().name("A2").build()))
+                .categories(Set.of(CategoryEntity.builder().name("Action").build(), CategoryEntity.builder().name("Sci-Fi").build()))
+                .build();
+        writer.writeMetadataToFile(cbz, md, null, false, new MetadataClearFlags());
+
+        Document doc = readComicInfo(cbz);
+        Element root = doc.getDocumentElement();
+        assertThat(root.getElementsByTagName("Title").item(0).getTextContent()).isEqualTo("Sample");
+        assertThat(root.getElementsByTagName("Summary").item(0).getTextContent()).isEqualTo("Desc");
+        assertThat(root.getElementsByTagName("Publisher").item(0).getTextContent()).isEqualTo("Pub");
+        assertThat(root.getElementsByTagName("Series").item(0).getTextContent()).isEqualTo("Series");
+        assertThat(root.getElementsByTagName("Number").item(0).getTextContent()).isEqualTo("1");
+        assertThat(root.getElementsByTagName("Count").item(0).getTextContent()).isEqualTo("5");
+        assertThat(root.getElementsByTagName("Year").item(0).getTextContent()).isEqualTo("2022");
+        assertThat(root.getElementsByTagName("Month").item(0).getTextContent()).isEqualTo("3");
+        assertThat(root.getElementsByTagName("Day").item(0).getTextContent()).isEqualTo("4");
+        assertThat(root.getElementsByTagName("PageCount").item(0).getTextContent()).isEqualTo("30");
+        assertThat(root.getElementsByTagName("LanguageISO").item(0).getTextContent()).isEqualTo("en");
+        assertThat(root.getElementsByTagName("Writer").item(0).getTextContent()).contains("A1").contains("A2");
+        assertThat(root.getElementsByTagName("Genre").item(0).getTextContent()).contains("Action").contains("Sci-Fi");
+    }
+
+    @Test
+    void updatesExistingComicInfoCaseInsensitive() throws Exception {
+        String xml = "<ComicInfo><Title>Old</Title></ComicInfo>";
+        File cbz = createCbz("existing.cbz", "comicinfo.xml", xml);
+        BookMetadataEntity md = BookMetadataEntity.builder().title("New").build();
+        writer.writeMetadataToFile(cbz, md, null, false, new MetadataClearFlags());
+
+        try (ZipFile zip = new ZipFile(cbz)) {
+            long count = zip.stream().filter(e -> e.getName().equalsIgnoreCase("ComicInfo.xml")).count();
+            assertThat(count).isEqualTo(1);
+        }
+        Document doc = readComicInfo(cbz);
+        assertThat(doc.getElementsByTagName("Title").item(0).getTextContent()).isEqualTo("New");
+    }
+}


### PR DESCRIPTION
## Summary
- parse ComicInfo.xml from CBZ archives to populate BookMetadata
- write updated metadata back into ComicInfo.xml when saving
- add tests verifying metadata writing and case-insensitive handling

## Testing
- `./gradlew test` *(fails: Could not resolve org.springframework.boot:spring-boot-starter-test:3.5.1 ... 403 Forbidden)*

------
https://chatgpt.com/codex/tasks/task_e_689a858837708320a6c3e3cc3fa3f79c