### PR TITLE
Use series metadata for comic search terms

### DIFF
--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/AmazonBookParser.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/AmazonBookParser.java
@@ -182,7 +182,10 @@ public class AmazonBookParser implements BookParser {
                     .collect(Collectors.joining(" "));
             searchTerm.append(cleanedTitle);
         } else {
-            String filename = BookUtils.cleanAndTruncateSearchTerm(BookUtils.cleanFileName(book.getFileName()));
+            String comicTerm = BookUtils.buildComicSearchTerm(book);
+            String filename = comicTerm != null
+                    ? BookUtils.cleanAndTruncateSearchTerm(comicTerm)
+                    : BookUtils.cleanAndTruncateSearchTerm(BookUtils.cleanFileName(book.getFileName()));
             if (!filename.isEmpty()) {
                 String cleanedFilename = Arrays.stream(filename.split(" "))
                         .map(word -> word.replaceAll("[^a-zA-Z0-9]", "").trim())

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/ComicvineBookParser.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/ComicvineBookParser.java
@@ -97,7 +97,12 @@ public class ComicvineBookParser implements BookParser {
     private String getSearchTerm(Book book, FetchMetadataRequest request) {
         if (request.getTitle() != null && !request.getTitle().isEmpty()) {
             return request.getTitle();
-        } else if (book.getFileName() != null && !book.getFileName().isEmpty()) {
+        }
+        String comicTerm = BookUtils.buildComicSearchTerm(book);
+        if (comicTerm != null) {
+            return comicTerm;
+        }
+        if (book.getFileName() != null && !book.getFileName().isEmpty()) {
             return BookUtils.cleanFileName(book.getFileName());
         }
         return null;

--- a/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/GoodReadsParser.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/service/metadata/parser/GoodReadsParser.java
@@ -349,11 +349,16 @@ public class GoodReadsParser implements BookParser {
     }
 
     private String getSearchTerm(Book book, FetchMetadataRequest request) {
-        return (request.getTitle() != null && !request.getTitle().isEmpty())
-                ? request.getTitle()
-                : (book.getFileName() != null && !book.getFileName().isEmpty()
+        if (request.getTitle() != null && !request.getTitle().isEmpty()) {
+            return request.getTitle();
+        }
+        String comicTerm = BookUtils.buildComicSearchTerm(book);
+        if (comicTerm != null) {
+            return comicTerm;
+        }
+        return (book.getFileName() != null && !book.getFileName().isEmpty())
                 ? BookUtils.cleanFileName(book.getFileName())
-                : null);
+                : null;
     }
 
     private Integer extractGoodReadsIdPreview(Element book) {

--- a/booklore-api/src/main/java/com/adityachandel/booklore/util/BookUtils.java
+++ b/booklore-api/src/main/java/com/adityachandel/booklore/util/BookUtils.java
@@ -1,4 +1,5 @@
 package com.adityachandel.booklore.util;
+import com.adityachandel.booklore.model.dto.Book;
 
 public class BookUtils {
 
@@ -16,7 +17,7 @@ public class BookUtils {
     }
 
     public static String cleanAndTruncateSearchTerm(String term) {
-        term = term.replaceAll("[.,\\-\\[\\]{}()!@#$%^&*_=+|~`<>?/\";:]", "").trim();
+        term = term.replaceAll("[^\\p{Alnum}# ]", "").trim();
         if (term.length() > 60) {
             String[] words = term.split("\\s+");
             StringBuilder truncated = new StringBuilder();
@@ -28,5 +29,21 @@ public class BookUtils {
             term = truncated.toString();
         }
         return term;
+    }
+
+    public static String buildComicSearchTerm(Book book) {
+        if (book == null || book.getMetadata() == null) {
+            return null;
+        }
+        String seriesName = book.getMetadata().getSeriesName();
+        Float seriesNumber = book.getMetadata().getSeriesNumber();
+        if (seriesName == null || seriesName.isBlank() || seriesNumber == null) {
+            return null;
+        }
+        int intValue = seriesNumber.intValue();
+        String issue = seriesNumber.equals((float) intValue)
+                ? String.valueOf(intValue)
+                : seriesNumber.toString();
+        return seriesName + " #" + issue;
     }
 }

--- a/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/parser/ParserSearchTermTest.java
+++ b/booklore-api/src/test/java/com/adityachandel/booklore/service/metadata/parser/ParserSearchTermTest.java
@@ -1,0 +1,50 @@
+package com.adityachandel.booklore.service.metadata.parser;
+
+import com.adityachandel.booklore.model.dto.Book;
+import com.adityachandel.booklore.model.dto.BookMetadata;
+import com.adityachandel.booklore.model.dto.request.FetchMetadataRequest;
+import com.fasterxml.jackson.databind.ObjectMapper;
+import org.junit.jupiter.api.Test;
+import org.springframework.test.util.ReflectionTestUtils;
+
+import static org.assertj.core.api.Assertions.assertThat;
+
+public class ParserSearchTermTest {
+
+    private Book comicBook() {
+        return Book.builder()
+                .fileName("renamed.cbz")
+                .metadata(BookMetadata.builder()
+                        .seriesName("SeriesName")
+                        .seriesNumber(1f)
+                        .build())
+                .build();
+    }
+
+    @Test
+    void comicvineUsesSeriesSearchTermWhenFileRenamed() {
+        Book book = comicBook();
+        FetchMetadataRequest request = FetchMetadataRequest.builder().build();
+        ComicvineBookParser parser = new ComicvineBookParser(new ObjectMapper(), null);
+        String term = ReflectionTestUtils.invokeMethod(parser, "getSearchTerm", book, request);
+        assertThat(term).isEqualTo("SeriesName #1");
+    }
+
+    @Test
+    void goodreadsUsesSeriesSearchTermWhenFileRenamed() {
+        Book book = comicBook();
+        FetchMetadataRequest request = FetchMetadataRequest.builder().build();
+        GoodReadsParser parser = new GoodReadsParser();
+        String term = ReflectionTestUtils.invokeMethod(parser, "getSearchTerm", book, request);
+        assertThat(term).isEqualTo("SeriesName #1");
+    }
+
+    @Test
+    void googleUsesSeriesSearchTermWhenFileRenamed() {
+        Book book = comicBook();
+        FetchMetadataRequest request = FetchMetadataRequest.builder().build();
+        GoogleParser parser = new GoogleParser(new ObjectMapper());
+        String term = ReflectionTestUtils.invokeMethod(parser, "getSearchTerm", book, request);
+        assertThat(term).isEqualTo("SeriesName #1");
+    }
+}


### PR DESCRIPTION
## Summary
- build comic search terms from series name and issue number
- prefer comic search term in metadata providers before filename cleaning
- verify parsers search by series and issue even after file rename

## Testing
- `./gradlew test` *(fails: Could not GET maven resources; status code 403)*

------
https://chatgpt.com/codex/tasks/task_e_689ad8d5b9d8832081c3eb32103c5945